### PR TITLE
Build and test in CI

### DIFF
--- a/.github/workflows/bash.nix
+++ b/.github/workflows/bash.nix
@@ -1,0 +1,4 @@
+import (builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/4ecab3273592f27479a583fb6d975d4aba3486fe.tar.gz";
+      sha256 = "10wn0l08j9lgqcw8177nh2ljrnxdrpri7bp0g7nvrsn9rkawvlbf";
+    }) {}

--- a/.github/workflows/bash.nix
+++ b/.github/workflows/bash.nix
@@ -1,4 +1,4 @@
 import (builtins.fetchTarball {
-      url = "https://github.com/NixOS/nixpkgs/archive/4ecab3273592f27479a583fb6d975d4aba3486fe.tar.gz";
-      sha256 = "10wn0l08j9lgqcw8177nh2ljrnxdrpri7bp0g7nvrsn9rkawvlbf";
-    }) {}
+  url = "https://github.com/NixOS/nixpkgs/archive/4ecab3273592f27479a583fb6d975d4aba3486fe.tar.gz";
+  sha256 = "10wn0l08j9lgqcw8177nh2ljrnxdrpri7bp0g7nvrsn9rkawvlbf";
+}) {}

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04, macos-13]
-        ghc: [ghc88, ghc96, ghc810, ghc884, ghc90]
+        ghc: [ghc7103, ghc802, ghc822, ghc844, ghc865Binary, ghc88, ghc96, ghc810, ghc884, ghc90]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -12,17 +12,15 @@ jobs:
         os: [ubuntu-22.04, ubuntu-20.04, macos-13, macos-14]
         ghc: [ghc7103, ghc802, ghc822, ghc844, ghc865Binary, ghc884, ghc810, ghc90, ghc92, ghc94, ghc96]
         cc: [gcc8, gcc12, gcc14, clang_12, clang_16, clang_18]
-        isMacos:
-          - ${{ startsWith(matrix.os, 'macos-') }}
         exclude:
-          # GHC version >= 7.10 and <= 8.4 are provided by a version of nixpkgs that is broken for macOS (cf. https://github.com/NixOS/nixpkgs/issues/104580)
-          - isMacos: true
+          # GHC version >= 7.10 and <= 8.4 are provided by a version of nixpkgs that is broken for macos-13 (cf. https://github.com/NixOS/nixpkgs/issues/104580)
+          - os: macos-13
             ghc: ghc7103
-          - isMacos: true
+          - os: macos-13
             ghc: ghc802
-          - isMacos: true
+          - os: macos-13
             ghc: ghc822
-          - isMacos: true
+          - os: macos-13
             ghc: ghc844
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -13,7 +13,7 @@ jobs:
         ghc: [ghc7103, ghc802, ghc822, ghc844, ghc865Binary, ghc884, ghc810, ghc90, ghc92, ghc94, ghc96]
         cc: [gcc8, gcc12, gcc14, clang_12, clang_16, clang_18]
         isMacos:
-          - ${{ startsWith(os, 'macos-') }}
+          - ${{ startsWith(matrix.os, 'macos-') }}
         exclude:
           # GHC version >= 7.10 and <= 8.4 are provided by a version of nixpkgs that is broken for macOS (cf. https://github.com/NixOS/nixpkgs/issues/104580)
           - isMacos: true

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -11,6 +11,16 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04, macos-13]
         ghc: [ghc7103, ghc802, ghc822, ghc844, ghc865Binary, ghc884, ghc810, ghc90, ghc92, ghc94, ghc96]
+        exclude:
+          # GHC version >= 7.10 and <= 8.4 are provided by a version of nixpkgs that is broken for macos-13 (cf. https://github.com/NixOS/nixpkgs/issues/104580)
+          - os: macos-13
+            ghc: ghc7103
+          - os: macos-13
+            ghc: ghc802
+          - os: macos-13
+            ghc: ghc822
+          - os: macos-13
+            ghc: ghc844
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -54,3 +54,7 @@ jobs:
 
       - name: Run tests
         run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'cabal test --test-show-details direct' # "--test-show-details direct" makes cabal print test suite output to terminal
+
+      - name: Run failed tests
+        if: failure()
+        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'cabal test --test-show-details failures'

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04, macos-13]
         ghc: [ghc7103, ghc802, ghc822, ghc844, ghc865Binary, ghc884, ghc810, ghc90, ghc92, ghc94, ghc96]
-        cc: [gcc8, gcc9, gcc10, gcc11, gcc12, gcc13, gcc14, clang_12, clang_13, clang_14, clang_15, clang_16, clang_18]
+        cc: [gcc8, gcc10, gcc12, gcc14, clang_12, clang_16, clang_18]
         exclude:
           # GHC version >= 7.10 and <= 8.4 are provided by a version of nixpkgs that is broken for macos-13 (cf. https://github.com/NixOS/nixpkgs/issues/104580)
           - os: macos-13

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -13,7 +13,7 @@ jobs:
         ghc: [ghc7103, ghc802, ghc822, ghc844, ghc865Binary, ghc884, ghc810, ghc90, ghc92, ghc94, ghc96]
         cc: [gcc8, gcc12, gcc14, clang_12, clang_16, clang_18]
         isMacos:
-          - ${{ startsWith(matrix.os, 'macos-') }}
+          - ${{ startsWith(os, 'macos-') }}
         exclude:
           # GHC version >= 7.10 and <= 8.4 are provided by a version of nixpkgs that is broken for macOS (cf. https://github.com/NixOS/nixpkgs/issues/104580)
           - isMacos: true

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -1,0 +1,49 @@
+name: Build & test in nix-shell
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build_test:
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-20.04, macos-14, macos-13, macos-12]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v25
+        with:
+          install_url: https://releases.nixos.org/nix/nix-2.20.5/install
+          extra_nix_config: |
+            substituters = https://cache.nixos.org https://cache.iog.io
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+            system-features = benchmark big-parallel kvm nixos-test
+
+      - name: Cache cabal files
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.os }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.os }}-
+
+      - name: Test nix-shell # test that the Nix shell actually works
+        run: nix-shell --run 'echo $PATH; ls -l $(which ghc); ls -l $(which cabal); ghc --version; cabal --version; type cabal'
+
+      - name: Run 'cabal update'
+        run: nix-shell --run 'cabal update'
+
+      - name: Build library
+        run: nix-shell --run 'cabal build lib:packman'
+
+      - name: Build tests
+        run: nix-shell --run 'cabal build --enable-tests'
+
+      - name: Run tests
+        run: nix-shell --run 'cabal test --test-show-details direct' # "--test-show-details direct" makes cabal print test suite output to terminal

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Run tests
         run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --argstr ccVersion ${{ matrix.cc }} --run 'cabal test --test-show-details direct' # "--test-show-details direct" makes cabal print test suite output to terminal
 
+      # Run all tests again showing only the output of failed tests
       - name: Run failed tests
         if: failure()
         run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --argstr ccVersion ${{ matrix.cc }} --run 'cabal test --test-show-details failures'

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -43,7 +43,7 @@ jobs:
             substituters = https://cache.nixos.org https://cache.iog.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
             system-features = benchmark big-parallel kvm nixos-test
-            system = x86_64-darwin
+            ${{ startsWith(matrix.os, "macos") && 'system = x86_64-darwin' || '' }}
 
       - name: Cache cabal files
         uses: actions/cache@v3

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -12,15 +12,17 @@ jobs:
         os: [ubuntu-22.04, ubuntu-20.04, macos-13, macos-14]
         ghc: [ghc7103, ghc802, ghc822, ghc844, ghc865Binary, ghc884, ghc810, ghc90, ghc92, ghc94, ghc96]
         cc: [gcc8, gcc12, gcc14, clang_12, clang_16, clang_18]
+        isMacos:
+          - ${{ startsWith(matrix.os, 'macos-') }}
         exclude:
-          # GHC version >= 7.10 and <= 8.4 are provided by a version of nixpkgs that is broken for macos-13 (cf. https://github.com/NixOS/nixpkgs/issues/104580)
-          - os: macos-13
+          # GHC version >= 7.10 and <= 8.4 are provided by a version of nixpkgs that is broken for macOS (cf. https://github.com/NixOS/nixpkgs/issues/104580)
+          - isMacos: true
             ghc: ghc7103
-          - os: macos-13
+          - isMacos: true
             ghc: ghc802
-          - os: macos-13
+          - isMacos: true
             ghc: ghc822
-          - os: macos-13
+          - isMacos: true
             ghc: ghc844
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -40,16 +40,16 @@ jobs:
         run: echo "NIX_BUILD_SHELL=$(nix-build -A bash .github/workflows/bash.nix)/bin/bash" >> $GITHUB_ENV
 
       - name: Test nix-shell # test that the Nix shell actually works
-        run: nix-shell --run --argstr ghcVersion ${{ matrix.ghc }} 'echo $PATH; ls -l $(which ghc); ls -l $(which cabal); ghc --version; cabal --version; type cabal'
+        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'echo $PATH; ls -l $(which ghc); ls -l $(which cabal); ghc --version; cabal --version; type cabal'
 
       - name: Run 'cabal update'
-        run: nix-shell --run --argstr ghcVersion ${{ matrix.ghc }} 'cabal update'
+        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'cabal update'
 
       - name: Build library
-        run: nix-shell --run --argstr ghcVersion ${{ matrix.ghc }} 'cabal build lib:packman'
+        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'cabal build lib:packman'
 
       - name: Build tests
-        run: nix-shell --run --argstr ghcVersion ${{ matrix.ghc }} 'cabal build --enable-tests'
+        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'cabal build --enable-tests'
 
       - name: Run tests
-        run: nix-shell --run --argstr ghcVersion ${{ matrix.ghc }} 'cabal test --test-show-details direct' # "--test-show-details direct" makes cabal print test suite output to terminal
+        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'cabal test --test-show-details direct' # "--test-show-details direct" makes cabal print test suite output to terminal

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04, macos-13]
+        ghc: [ghc88, ghc96, ghc810, ghc884 or ghc90]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -30,7 +31,7 @@ jobs:
             ~/.cabal/packages
             ~/.cabal/store
             dist-newstyle
-          key: ${{ runner.os }}-${{ matrix.os }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}
+          key: ${{ runner.os }}-${{ matrix.os }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}--${{ matrix.ghc }}
           restore-keys: ${{ runner.os }}-${{ matrix.os }}-
 
       # Make nix-shell use specific Bash version.
@@ -39,16 +40,16 @@ jobs:
         run: echo "NIX_BUILD_SHELL=$(nix-build -A bash .github/workflows/bash.nix)/bin/bash" >> $GITHUB_ENV
 
       - name: Test nix-shell # test that the Nix shell actually works
-        run: nix-shell --run 'echo $PATH; ls -l $(which ghc); ls -l $(which cabal); ghc --version; cabal --version; type cabal'
+        run: nix-shell --run --argstr ghcVersion ${{ matrix.ghc }} 'echo $PATH; ls -l $(which ghc); ls -l $(which cabal); ghc --version; cabal --version; type cabal'
 
       - name: Run 'cabal update'
-        run: nix-shell --run 'cabal update'
+        run: nix-shell --run --argstr ghcVersion ${{ matrix.ghc }} 'cabal update'
 
       - name: Build library
-        run: nix-shell --run 'cabal build lib:packman'
+        run: nix-shell --run --argstr ghcVersion ${{ matrix.ghc }} 'cabal build lib:packman'
 
       - name: Build tests
-        run: nix-shell --run 'cabal build --enable-tests'
+        run: nix-shell --run --argstr ghcVersion ${{ matrix.ghc }} 'cabal build --enable-tests'
 
       - name: Run tests
-        run: nix-shell --run 'cabal test --test-show-details direct' # "--test-show-details direct" makes cabal print test suite output to terminal
+        run: nix-shell --run --argstr ghcVersion ${{ matrix.ghc }} 'cabal test --test-show-details direct' # "--test-show-details direct" makes cabal print test suite output to terminal

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -33,6 +33,11 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.os }}-${{ hashFiles('**/*.cabal', '**/cabal.project', '**/cabal.project.freeze') }}
           restore-keys: ${{ runner.os }}-${{ matrix.os }}-
 
+      # Make nix-shell use specific Bash version.
+      # Cf. https://nixos.org/manual/nix/stable/command-ref/nix-shell#environment-variables.
+      - name: Set shell Bash
+        run: echo "NIX_BUILD_SHELL=$(nix-build -A bash .github/workflows/bash.nix)/bin/bash" >> $GITHUB_ENV
+
       - name: Test nix-shell # test that the Nix shell actually works
         run: nix-shell --run 'echo $PATH; ls -l $(which ghc); ls -l $(which cabal); ghc --version; cabal --version; type cabal'
 

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -13,7 +13,7 @@ jobs:
         ghc: [ghc7103, ghc802, ghc822, ghc844, ghc865Binary, ghc884, ghc810, ghc90, ghc92, ghc94, ghc96]
         cc: [gcc8, gcc12, gcc14, clang_12, clang_16, clang_18]
         exclude:
-          # GHC version >= 7.10 and <= 8.4 are provided by a version of nixpkgs that is broken for macos-13 (cf. https://github.com/NixOS/nixpkgs/issues/104580)
+          # GHC version >= 7.10 and <= 8.4 are provided by a version of nixpkgs that is broken for macOS (cf. https://github.com/NixOS/nixpkgs/issues/104580)
           - os: macos-13
             ghc: ghc7103
           - os: macos-13
@@ -21,6 +21,14 @@ jobs:
           - os: macos-13
             ghc: ghc822
           - os: macos-13
+            ghc: ghc844
+          - os: macos-14
+            ghc: ghc7103
+          - os: macos-14
+            ghc: ghc802
+          - os: macos-14
+            ghc: ghc822
+          - os: macos-14
             ghc: ghc844
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -8,7 +8,7 @@ jobs:
   build_test:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, macos-14, macos-13, macos-12]
+        os: [ubuntu-22.04, ubuntu-20.04, macos-14, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -40,11 +40,11 @@ jobs:
       - name: Set shell Bash
         run: echo "NIX_BUILD_SHELL=$(nix-build -A bash .github/workflows/bash.nix)/bin/bash" >> $GITHUB_ENV
 
-      - name: Export GHC version env var
-        run: echo "GHC_VERSION=$(nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'ghc --numeric-version')" >> $GITHUB_ENV
-
       - name: Test nix-shell # test that the Nix shell actually works
         run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'echo $PATH; ls -l $(which ghc); ls -l $(which cabal); ghc --version; cabal --version; type cabal'
+
+      - name: Export GHC version env var
+        run: echo "GHC_VERSION=$(nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'ghc --numeric-version')" >> $GITHUB_ENV
 
       - name: Run 'cabal update'
         run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'cabal update'

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, macos-13]
+        os: [ubuntu-22.04, ubuntu-20.04, macos-13, macos-14]
         ghc: [ghc7103, ghc802, ghc822, ghc844, ghc865Binary, ghc884, ghc810, ghc90, ghc92, ghc94, ghc96]
         cc: [gcc8, gcc10, gcc12, gcc14, clang_12, clang_16, clang_18]
         exclude:
@@ -35,6 +35,7 @@ jobs:
             substituters = https://cache.nixos.org https://cache.iog.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
             system-features = benchmark big-parallel kvm nixos-test
+            system = x86_64-darwin
 
       - name: Cache cabal files
         uses: actions/cache@v3

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04, macos-13]
-        ghc: [ghc7103, ghc802, ghc822, ghc844, ghc865Binary, ghc88, ghc96, ghc810, ghc884, ghc90]
+        ghc: [ghc7103, ghc802, ghc822, ghc844, ghc865Binary, ghc884, ghc810, ghc90, ghc92, ghc94, ghc96]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -43,7 +43,7 @@ jobs:
             substituters = https://cache.nixos.org https://cache.iog.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
             system-features = benchmark big-parallel kvm nixos-test
-            ${{ startsWith(matrix.os, "macos") && 'system = x86_64-darwin' || '' }}
+            ${{ startsWith(matrix.os, 'macos') && 'system = x86_64-darwin' || '' }}
 
       - name: Cache cabal files
         uses: actions/cache@v3

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -41,7 +41,7 @@ jobs:
         run: echo "NIX_BUILD_SHELL=$(nix-build -A bash .github/workflows/bash.nix)/bin/bash" >> $GITHUB_ENV
 
       - name: Export GHC version env var
-        run: echo "GHC_VERSION=$(ghc --numeric-version)" >> $GITHUB_ENV
+        run: echo "GHC_VERSION=$(nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'ghc --numeric-version')" >> $GITHUB_ENV
 
       - name: Test nix-shell # test that the Nix shell actually works
         run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'echo $PATH; ls -l $(which ghc); ls -l $(which cabal); ghc --version; cabal --version; type cabal'

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -13,7 +13,7 @@ jobs:
         ghc: [ghc7103, ghc802, ghc822, ghc844, ghc865Binary, ghc884, ghc810, ghc90, ghc92, ghc94, ghc96]
         cc: [gcc8, gcc12, gcc14, clang_12, clang_16, clang_18]
         exclude:
-          # GHC version >= 7.10 and <= 8.4 are provided by a version of nixpkgs that is broken for macOS (cf. https://github.com/NixOS/nixpkgs/issues/104580)
+          # GHC version >= 7.10 and <= 8.4 are provided by a version of nixpkgs that is broken for macOS (cf. https://github.com/NixOS/nixpkgs/issues/104580) so we exlude these
           - os: macos-13
             ghc: ghc7103
           - os: macos-13
@@ -39,6 +39,7 @@ jobs:
         uses: cachix/install-nix-action@v25
         with:
           install_url: https://releases.nixos.org/nix/nix-2.20.5/install
+          # NOTE: We avoid using arm64 builds of GHC (because they're mostly broken for early GHC versions) by specifying 'system = x86_64-darwin' for macOS runners
           extra_nix_config: |
             substituters = https://cache.nixos.org https://cache.iog.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -8,7 +8,7 @@ jobs:
   build_test:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, macos-14, macos-13]
+        os: [ubuntu-22.04, ubuntu-20.04, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Set shell Bash
         run: echo "NIX_BUILD_SHELL=$(nix-build -A bash .github/workflows/bash.nix)/bin/bash" >> $GITHUB_ENV
 
+      - name: Export GHC version env var
+        run: echo "GHC_VERSION=$(ghc --numeric-version)" >> $GITHUB_ENV
+
       - name: Test nix-shell # test that the Nix shell actually works
         run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'echo $PATH; ls -l $(which ghc); ls -l $(which cabal); ghc --version; cabal --version; type cabal'
 

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04, macos-13, macos-14]
         ghc: [ghc7103, ghc802, ghc822, ghc844, ghc865Binary, ghc884, ghc810, ghc90, ghc92, ghc94, ghc96]
-        cc: [gcc8, gcc10, gcc12, gcc14, clang_12, clang_16, clang_18]
+        cc: [gcc8, gcc12, gcc14, clang_12, clang_16, clang_18]
         exclude:
           # GHC version >= 7.10 and <= 8.4 are provided by a version of nixpkgs that is broken for macos-13 (cf. https://github.com/NixOS/nixpkgs/issues/104580)
           - os: macos-13

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04, macos-13]
         ghc: [ghc7103, ghc802, ghc822, ghc844, ghc865Binary, ghc884, ghc810, ghc90, ghc92, ghc94, ghc96]
+        cc: [gcc8, gcc9, gcc10, gcc11, gcc12, gcc13, gcc14, clang_12, clang_13, clang_14, clang_15, clang_16, clang_18]
         exclude:
           # GHC version >= 7.10 and <= 8.4 are provided by a version of nixpkgs that is broken for macos-13 (cf. https://github.com/NixOS/nixpkgs/issues/104580)
           - os: macos-13
@@ -51,23 +52,23 @@ jobs:
         run: echo "NIX_BUILD_SHELL=$(nix-build -A bash .github/workflows/bash.nix)/bin/bash" >> $GITHUB_ENV
 
       - name: Test nix-shell # test that the Nix shell actually works
-        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'echo $PATH; ls -l $(which ghc); ls -l $(which cabal); ghc --version; cabal --version; type cabal'
+        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --argstr ccVersion ${{ matrix.cc }} --run 'echo $PATH; ls -l $(which ghc); ls -l $(which cabal); ghc --version; cabal --version; type cabal'
 
       - name: Export GHC version env var
-        run: echo "GHC_VERSION=$(nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'ghc --numeric-version')" >> $GITHUB_ENV
+        run: echo "GHC_VERSION=$(nix-shell --argstr ghcVersion ${{ matrix.ghc }} --argstr ccVersion ${{ matrix.cc }} --run 'ghc --numeric-version')" >> $GITHUB_ENV
 
       - name: Run 'cabal update'
-        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'cabal update'
+        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --argstr ccVersion ${{ matrix.cc }} --run 'cabal update'
 
       - name: Build library
-        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'cabal build lib:packman'
+        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --argstr ccVersion ${{ matrix.cc }} --run 'cabal build lib:packman'
 
       - name: Build tests
-        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'cabal build --enable-tests'
+        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --argstr ccVersion ${{ matrix.cc }} --run 'cabal build --enable-tests'
 
       - name: Run tests
-        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'cabal test --test-show-details direct' # "--test-show-details direct" makes cabal print test suite output to terminal
+        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --argstr ccVersion ${{ matrix.cc }} --run 'cabal test --test-show-details direct' # "--test-show-details direct" makes cabal print test suite output to terminal
 
       - name: Run failed tests
         if: failure()
-        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --run 'cabal test --test-show-details failures'
+        run: nix-shell --argstr ghcVersion ${{ matrix.ghc }} --argstr ccVersion ${{ matrix.cc }} --run 'cabal test --test-show-details failures'

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build_test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04, macos-13]
         ghc: [ghc88, ghc96, ghc810, ghc884, ghc90]

--- a/.github/workflows/cabal-in-nix-shell.yml
+++ b/.github/workflows/cabal-in-nix-shell.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04, macos-13]
-        ghc: [ghc88, ghc96, ghc810, ghc884 or ghc90]
+        ghc: [ghc88, ghc96, ghc810, ghc884, ghc90]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/shell.nix
+++ b/shell.nix
@@ -5,10 +5,10 @@ let
       sha256 = "10wn0l08j9lgqcw8177nh2ljrnxdrpri7bp0g7nvrsn9rkawvlbf";
     }) {};
 
-  pkgsGcc =
+  pkgs2405 =
     import (builtins.fetchTarball {
-      url = "https://github.com/NixOS/nixpkgs/archive/release-24.05.tar.gz";
-      sha256 = "0asfn6clphn8gb0d17l6mc4yxwc3xr41hndq2s49wyl5siyi1730";
+      url = "https://github.com/NixOS/nixpkgs/archive/31ac92f9628682b294026f0860e14587a09ffb4b.tar.gz";
+      sha256 = "0qbyywfgjljfb4izdngxvbyvbrkilmpsmmx2a9spbwir2bcmbi14";
     }) {};
 in
 pkgs.mkShell {
@@ -16,7 +16,7 @@ pkgs.mkShell {
     pkgs.haskell.compiler.ghc88
     pkgs.cabal-install
     pkgs.git
-    pkgsGcc.gcc9 # later versions fail with issue https://github.com/jberthold/packman/issues/17
+    pkgs2405.gcc9 # later versions fail with issue https://github.com/jberthold/packman/issues/17
   ];
 }
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,3 +1,5 @@
+{ ghcVersion ? "ghc90"
+} :
 let
   pkgs =
     import (builtins.fetchTarball {
@@ -13,7 +15,7 @@ let
 in
 pkgs.mkShell {
   nativeBuildInputs = [
-    pkgs.haskell.compiler.ghc90
+    pkgs.haskell.compiler.${ghcVersion}
     pkgs.cabal-install
     pkgs.git
     pkgs2405.gcc9 # later versions fail with issue https://github.com/jberthold/packman/issues/17

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,5 @@
 { ghcVersion ? "ghc90"
+, ccVersion ? "gcc9"
 } :
 let
   pkgs =
@@ -26,7 +27,7 @@ pkgs.mkShell {
     ghc
     pkgs.cabal-install
     pkgs.git
-    pkgs2405.gcc9 # later versions fail with issue https://github.com/jberthold/packman/issues/17
+    pkgs2405.${ccVersion}
   ];
 }
 

--- a/shell.nix
+++ b/shell.nix
@@ -7,15 +7,23 @@ let
       sha256 = "10wn0l08j9lgqcw8177nh2ljrnxdrpri7bp0g7nvrsn9rkawvlbf";
     }) {};
 
+  pkgs1809 =
+    import (builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/925ff360bc33876fdb6ff967470e34ff375ce65e.tar.gz";
+      sha256 = "1qbmp6x01ika4kdc7bhqawasnpmhyl857ldz25nmq9fsmqm1vl2s";
+    }) {};
+
   pkgs2405 =
     import (builtins.fetchTarball {
       url = "https://github.com/NixOS/nixpkgs/archive/31ac92f9628682b294026f0860e14587a09ffb4b.tar.gz";
       sha256 = "0qbyywfgjljfb4izdngxvbyvbrkilmpsmmx2a9spbwir2bcmbi14";
     }) {};
+
+  ghc = pkgs.haskell.compiler.${ghcVersion} or pkgs1809.haskell.compiler.${ghcVersion};
 in
 pkgs.mkShell {
   nativeBuildInputs = [
-    pkgs.haskell.compiler.${ghcVersion}
+    ghc
     pkgs.cabal-install
     pkgs.git
     pkgs2405.gcc9 # later versions fail with issue https://github.com/jberthold/packman/issues/17

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,22 @@
+let
+  pkgs =
+    import (builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/4ecab3273592f27479a583fb6d975d4aba3486fe.tar.gz";
+      sha256 = "10wn0l08j9lgqcw8177nh2ljrnxdrpri7bp0g7nvrsn9rkawvlbf";
+    }) {};
+
+  pkgsGcc =
+    import (builtins.fetchTarball {
+      url = "https://github.com/NixOS/nixpkgs/archive/release-24.05.tar.gz";
+      sha256 = "0asfn6clphn8gb0d17l6mc4yxwc3xr41hndq2s49wyl5siyi1730";
+    }) {};
+in
+pkgs.mkShell {
+  nativeBuildInputs = [
+    pkgs.haskell.compiler.ghc88
+    pkgs.cabal-install
+    pkgs.git
+    pkgsGcc.gcc9 # later versions fail with issue https://github.com/jberthold/packman/issues/17
+  ];
+}
+

--- a/shell.nix
+++ b/shell.nix
@@ -13,7 +13,7 @@ let
 in
 pkgs.mkShell {
   nativeBuildInputs = [
-    pkgs.haskell.compiler.ghc88
+    pkgs.haskell.compiler.ghc90
     pkgs.cabal-install
     pkgs.git
     pkgs2405.gcc9 # later versions fail with issue https://github.com/jberthold/packman/issues/17


### PR DESCRIPTION
# TODO

- [x] Test multiple GHC versions
- [x] Test multiple C compiler versions/flavors (also clang)

## Failures

### 1. `detailed` tests fail for old GHC versions

```
Test suite quickchecktest: RUNNING...
panic! read @TestSuiteLog ""
CallStack (from HasCallStack):
  error, called at src/Distribution/Simple/Test/LibV09.hs:133:34 in Cabal-3.10.1.0-5sSVeMY5t4HKsrW2wqIvsr:Distribution.Simple.Test.LibV09
```

Fix: https://github.com/runeksvendsen/packman/pull/2/commits/a42fb0e93b623c524fc1c77fe8ea40c314909717

### 2. `testmthread: Contains an unsupported closure type (whose implementation is missing) `

See existing issue https://github.com/jberthold/packman/issues/18
